### PR TITLE
Make installation snippets clipboard-friendly

### DIFF
--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -57,14 +57,14 @@ Configure tap for Couchbase:
 
 [source,console]
 ----
-$ brew tap couchbaselabs/homebrew-couchbase
+brew tap couchbaselabs/homebrew-couchbase
 ----
 
 Install the library:
 
 [source,console]
 ----
-$ brew install couchbase-cxx-client
+brew install couchbase-cxx-client
 ----
 
 === Install on RPM-based Systems
@@ -73,7 +73,7 @@ First, check how the platform identifies itself
 
 [source,console]
 ----
-$ rpm -E '%dist/%_arch' | sed 's/^\.//'
+rpm -E '%dist/%_arch' | sed 's/^\.//'
 ----
 
 This command would print the distribution/architecture part of the `.repo` URL.
@@ -139,7 +139,7 @@ First, check how the platform identifies itself:
 
 [source,console]
 ----
-$ (source /etc/os-release; echo ${VERSION_CODENAME}/$(uname -m))
+(source /etc/os-release; echo ${VERSION_CODENAME}/$(uname -m))
 ----
 
 This command prints the distribution/architecture part of the `.source` URL.
@@ -148,10 +148,6 @@ For example, for Ubuntu 20.04 on x86_64 architecture it prints the following:
 [source,console]
 ----
 $ (source /etc/os-release; echo ${VERSION_CODENAME}/$(uname -m))
-----
-
-[source,console]
-----
 jammy/x86_64
 ----
 
@@ -159,38 +155,30 @@ Ensure that `GnuPG` and `curl` are installed:
 
 [source,console]
 ----
-$ apt update && apt install curl gpg
+apt update && apt install curl gpg
 ----
 
-Now use this string to download the repository URL:
-
-[source,console]
-----
-$ DIST_ARCH=$(source /etc/os-release; echo ${VERSION_CODENAME}/$(uname -m))
-----
+Now use this string to download the repository GPG key and `.sources` file:
 
 [source,console]
 ----
-$ curl -L https://packages.couchbase.com/clients/cxx/repos/deb/${DIST_ARCH}/DEB-GPG-KEY.txt | \
+DIST_ARCH=$(source /etc/os-release; echo ${VERSION_CODENAME}/$(uname -m))
+curl -L https://packages.couchbase.com/clients/cxx/repos/deb/${DIST_ARCH}/DEB-GPG-KEY.txt | \
   gpg --yes --dearmor -o /usr/share/keyrings/couchbase-archive-keyring.gpg
-----
-
-[source,console]
-----
-$ curl -L -o/etc/apt/sources.list.d/couchbase-cxx-client.sources \
+curl -L -o/etc/apt/sources.list.d/couchbase-cxx-client.sources \
   https://packages.couchbase.com/clients/cxx/repos/deb/${DIST_ARCH}/couchbase-cxx-client.sources
 ----
 
 .Update the apt Sources
 [source,console]
 ----
-$ apt update
+apt update
 ----
 
 .Install the library with the headers:
 [source,console]
 ----
-$ apt install couchbase-cxx-client couchbase-cxx-client-dev
+apt install couchbase-cxx-client couchbase-cxx-client-dev
 ----
 
 .Install the command line tools:
@@ -202,5 +190,5 @@ apt install couchbase-cxx-client-tools
 Currently supported platforms are `aarch64` and `x86_64` for the following distributions:
 
 * `bookworm` Debian 12 (https://www.debian.org/releases/bookworm/).
-* `jammy` Ubuntu 20.04 (https://www.releases.ubuntu.com/jammy/).
-* `noble` Ubuntu 22.04 (https://www.releases.ubuntu.com/noble/).
+* `jammy` Ubuntu 22.04 (https://www.releases.ubuntu.com/jammy/).
+* `noble` Ubuntu 24.04 (https://www.releases.ubuntu.com/noble/).


### PR DESCRIPTION
* do not include prompt `$` if we do not show the command output
* group lines that depend on ENV variable into single sinppet