### PR TITLE
DNSSRV

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -150,8 +150,14 @@ Both the client and server require special configuration in this case.
 include::{version-common}@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv-rev]
 
 DNS SRV bootstrapping is enabled by default in the {name-sdk}.
-In order to make the SDK use the SRV records, you need to pass in the hostname from your records (here `example.com`):
+In order to make the SDK use the SRV records, you need to pass in the hostname or host address from your records (here `1.1.1.1`),
+and can also pass in a timeout value:
 
+[source,cpp]
+----
+options.dns().timeout(std::chrono::seconds{1});
+options.dns().nameserver("1.1.1.1");
+----
 
 
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -143,13 +143,14 @@ Both the client and server require special configuration in this case.
 
 
 
-=== Using DNS SRV records
 
-As an alternative to specifying multiple hosts in your program, you can get the actual bootstrap node list from a DNS SRV record. The following steps are necessary to make it work:
+// DNS-SRV
+// == Using DNS SRV records
 
-. Set up your DNS server to respond properly from a DNS SRV request.
-. Enable it on the SDK and point it towards the DNS SRV entry.
+include::{version-common}@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv-rev]
 
+DNS SRV bootstrapping is enabled by default in the {name-sdk}.
+In order to make the SDK use the SRV records, you need to pass in the hostname from your records (here `example.com`):
 
 
 


### PR DESCRIPTION
The sdk-common text is lines 41 to 87 of https://github.com/couchbase/docs-sdk-common/blob/release/7.6/modules/shared/partials/dnssrv-pars.adoc?plain=1

This can be seen (with additional, Scala specific details) at https://docs.couchbase.com/scala-sdk/current/howtos/managing-connections.html#using-dns-srv-records

QUESTION: The API ref only seems to have DNSSRV content for cbc-get - https://docs.couchbase.com/sdk-api/couchbase-cxx-client/cbc-get.html#autotoc_md17
Is there anything there to which I can link - or a client settings snippet to use?
@avsej @DemetrisChr 


DOC-10759 / DOC-12455